### PR TITLE
sudo_user is now become_user

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,7 @@
   when: item.key not in "{{ deployments.stdout.split('|') | default([]) }}"
 
 - name: Create deployments
-  sudo_user: rally
+  become_user: rally
   shell: source /home/rally/rally/bin/activate && rally deployment create --file /home/rally/{{ item.key }}/deploy.json --name {{ item.key }} && deactivate
   with_dict: "{{ clouds }}"
   when: item.key not in "{{ deployments.stdout.split('|') | default([]) }}"

--- a/tasks/tempest_verifiers.yml
+++ b/tasks/tempest_verifiers.yml
@@ -1,13 +1,13 @@
 ---
 - name: Check existing verifiers
-  sudo_user: rally
+  become_user: rally
   shell: source /home/rally/rally/bin/activate && rally deployment use {{ item.key }} &>/dev/null && rally verify list-verifiers | grep -v WARNING && deactivate
   register: verifiers
   args:
     executable: /bin/bash
 
 - name: Create verifier
-  sudo_user: rally
+  become_user: rally
   shell: "source /home/rally/rally/bin/activate && rally deployment use {{ item.key }} &>/dev/null && rally verify create-verifier --type tempest --name {{ item.key }} --source {{ tempest_source }} --version {{ tempest_version }}  && deactivate"
   when: item.key not in "{{ verifiers.stdout.split('|') | default([]) }}"
   args:
@@ -61,7 +61,7 @@
     args:
       executable: /bin/bash
 
-  sudo_user: rally
+  become_user: rally
   environment:
     ftp_proxy: ""
     http_proxy: ""


### PR DESCRIPTION
[DEPRECATION WARNING]: Instead of sudo/sudo_user, use become/become_user and make sure
 become_method is 'sudo' (default).
This feature will be removed in a future release. 
Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.
