### PR TITLE
Remove Jinja2 delimiters in when conditionals

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,25 +8,25 @@
 - name: Create directories for deployments
   file: path=/home/rally/{{ item.key }} owner=rally group=rally mode=0750 state=directory
   with_dict: "{{ clouds }}"
-  when: item.key not in "{{ deployments.stdout.split('|') | default([]) }}"
+  when: item.key not in deployments.stdout | default([])
 
 - name: Create deployment files
   template: src=deploy.json.j2 dest=/home/rally/{{ item.key }}/deploy.json owner=rally group=rally mode=0760
   with_dict: "{{ clouds }}"
-  when: item.key not in "{{ deployments.stdout.split('|') | default([]) }}"
+  when: item.key not in deployments.stdout | default([])
 
 - name: Create deployments
   become_user: rally
   shell: source /home/rally/rally/bin/activate && rally deployment create --file /home/rally/{{ item.key }}/deploy.json --name {{ item.key }} && deactivate
   with_dict: "{{ clouds }}"
-  when: item.key not in "{{ deployments.stdout.split('|') | default([]) }}"
+  when: item.key not in deployments.stdout | default([])
   args:
     executable: /bin/bash
 
 - name: Remove deployment directories
   file: path=/home/rally/{{ item.key }} state=absent
   with_dict: "{{ clouds }}"
-  when: item.key not in "{{ deployments.stdout.split('|') | default([]) }}"
+  when: item.key not in deployments.stdout | default([])
 
-- include: tempest.yml
+- import_tasks: tempest.yml
   when: configure_tempest

--- a/tasks/tempest.yml
+++ b/tasks/tempest.yml
@@ -4,5 +4,5 @@
     url: "http://download.cirros-cloud.net/0.3.5/cirros-0.3.5-x86_64-disk.img"
     dest: "/tmp/cirros-0.3.5-x86_64-disk.img"
 
-- include: tempest_verifiers.yml
+- include_tasks: tempest_verifiers.yml
   with_dict: "{{ clouds }}"

--- a/tasks/tempest_verifiers.yml
+++ b/tasks/tempest_verifiers.yml
@@ -1,7 +1,7 @@
 ---
 - name: Check existing verifiers
   become_user: rally
-  shell: source /home/rally/rally/bin/activate && rally deployment use {{ item.key }} &>/dev/null && rally verify list-verifiers | grep -v WARNING && deactivate
+  shell: "source /home/rally/rally/bin/activate && rally deployment use {{ item.key }} &>/dev/null && rally verify list-verifiers | grep -v WARNING && deactivate"
   register: verifiers
   args:
     executable: /bin/bash
@@ -9,7 +9,7 @@
 - name: Create verifier
   become_user: rally
   shell: "source /home/rally/rally/bin/activate && rally deployment use {{ item.key }} &>/dev/null && rally verify create-verifier --type tempest --name {{ item.key }} --source {{ tempest_source }} --version {{ tempest_version }}  && deactivate"
-  when: item.key not in "{{ verifiers.stdout.split('|') | default([]) }}"
+  when: item.key not in verifiers.stdout | default([])
   args:
     executable: /bin/bash
 


### PR DESCRIPTION
  * From Ansible 2.3 onwards there is a warning about using jinja2
    delimiters in when conditionals:
    `[WARNING]: when statements should not include jinja2 templating
    delimiters such as {{ }} or {% %}.` These have been removed from the
    role.

    The option `.split('|')` needs to change as it throws an error
    about being undefined the `{{ }}` braces are removed.

  * Change the `include` keyword to `import_tasks` now used in roles
    from Ansible 2.4 onwards.