### PR TITLE
Update tempest conf to use variables

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,6 +45,9 @@ configure_tempest: true
 tempest_source: https://git.openstack.org/openstack/tempest
 tempest_version: master
 
+# Tempest Openstack Roles
+rally_tempest_swift_operator_role: member
+rally_tempest_swift_reseller_admin_role: admin
 
 # Tempest uses two flavors for testing
 tempest_test_flavor: m1.tiny

--- a/templates/tempest.j2
+++ b/templates/tempest.j2
@@ -1,6 +1,6 @@
 [DEFAULT]
-swift_operator_role = member
-swift_reseller_admin_role = admin
+swift_operator_role = {{ rally_tempest_swift_operator_role }}
+swift_reseller_admin_role = {{ rally_tempest_swift_reseller_admin_role }}
 
 [compute]
 image_ref = {{ tempest_cirros_image_uuid }}
@@ -10,8 +10,11 @@ flavor_ref_alt = {{ tempest_second_flavor_uuid }}
 fixed_network_name = {{ tempest_network_name }}
 
 [object-storage]
-swift_operator_role = member
-swift_reseller_admin_role = admin
+swift_operator_role = {{ rally_tempest_swift_operator_role }}
+swift_reseller_admin_role = {{ rally_tempest_swift_reseller_admin_role }}
+
+[object-storage-feature-enabled]
+discoverability = {{ rally_tempest_swift_discoverability }}
 
 [volume]
 volume_size = 10


### PR DESCRIPTION
  * Set the options for swift_operator_role and
    swift_reseller_admin_role to use variables. These are set via the
    ansible-role-rally or your own group_vars
  * Add [object-storage-feature-enabled] discoverability, this is
    needed if you have a ceph rados gw backend for object store, this
    value is on by default if not set. However Tempest runs fails if
    using RadosGW. Allow this be configurable from group_vars
