### PR TITLE
Allow setting tempest.conf environment specific settings

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,6 +19,7 @@ clouds: {}
 #    user_domain_name: Default
 #    user_project_domain_name: Default
 #    network_name: network_name_for_tempest
+#    tempest_extra_settings: []
 #    tempest_skip_tests: {}
 # Which tempest tests to skip
 # Moving this under the clouds dictionary so you can have a skip test
@@ -42,6 +43,7 @@ clouds: {}
 #    user_domain_name: Default
 #    user_project_domain_name: Default
 #    network_name: netowork_name_for_tempest
+#    tempest_extra_settings: "{{ rally_tempest_extra_settings }}"
 #    tempest_skip_tests: {}
 # Which tempest tests to skip
 # Moving this under the clouds dictionary so you can have a skip test

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,7 @@
 - name: Check existing deployments
   shell: source /home/rally/rally/bin/activate && rally deployment list && deactivate
   register: deployments
+  changed_when: False
   args:
     executable: /bin/bash
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,17 +14,20 @@
   file: path=/home/rally/{{ item.key }} owner=rally group=rally mode=0750 state=directory
   with_dict: "{{ clouds }}"
   when: item.key not in deployments.stdout | default([])
+  no_log: True
 
 - name: Create deployment files
   template: src=deploy.json.j2 dest=/home/rally/{{ item.key }}/deploy.json owner=rally group=rally mode=0760
   with_dict: "{{ clouds }}"
   when: item.key not in deployments.stdout | default([])
+  no_log: True
 
 - name: Create deployments
   become_user: rally
   shell: source /home/rally/rally/bin/activate && rally deployment create --file /home/rally/{{ item.key }}/deploy.json --name {{ item.key }} && deactivate
   with_dict: "{{ clouds }}"
   when: item.key not in deployments.stdout | default([])
+  no_log: True
   args:
     executable: /bin/bash
 
@@ -32,6 +35,7 @@
   file: path=/home/rally/{{ item.key }} state=absent
   with_dict: "{{ clouds }}"
   when: item.key not in deployments.stdout | default([])
+  no_log: True
 
 - import_tasks: tempest.yml
   when: configure_tempest

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,20 +15,17 @@
   file: path=/home/rally/{{ item.key }} owner=rally group=rally mode=0750 state=directory
   with_dict: "{{ clouds }}"
   when: item.key not in deployments.stdout | default([])
-  no_log: True
 
 - name: Create deployment files
   template: src=deploy.json.j2 dest=/home/rally/{{ item.key }}/deploy.json owner=rally group=rally mode=0760
   with_dict: "{{ clouds }}"
   when: item.key not in deployments.stdout | default([])
-  no_log: True
 
 - name: Create deployments
   become_user: rally
   shell: source /home/rally/rally/bin/activate && rally deployment create --file /home/rally/{{ item.key }}/deploy.json --name {{ item.key }} && deactivate
   with_dict: "{{ clouds }}"
   when: item.key not in deployments.stdout | default([])
-  no_log: True
   args:
     executable: /bin/bash
 
@@ -36,7 +33,6 @@
   file: path=/home/rally/{{ item.key }} state=absent
   with_dict: "{{ clouds }}"
   when: item.key not in deployments.stdout | default([])
-  no_log: True
 
 - import_tasks: tempest.yml
   when: configure_tempest

--- a/tasks/tempest_verifiers.yml
+++ b/tasks/tempest_verifiers.yml
@@ -3,6 +3,7 @@
   become_user: rally
   shell: "source /home/rally/rally/bin/activate && rally deployment use {{ item.key }} &>/dev/null && rally verify list-verifiers | grep -v WARNING && deactivate"
   register: verifiers
+  changed_when: False
   args:
     executable: /bin/bash
 
@@ -18,6 +19,7 @@
     shell: "source /home/rally/rally/bin/activate && rally deployment use {{ item.key }} &>/dev/null && source ~/.rally/openrc && glance image-list --visibility public |grep cirros && deactivate"
     register: existing_images
     failed_when: existing_images.rc  > 1
+    changed_when: False
     args:
       executable: /bin/bash
 
@@ -31,18 +33,21 @@
   - name: Get image id
     shell: "source /home/rally/rally/bin/activate && rally deployment use {{ item.key }} &>/dev/null && source ~/.rally/openrc && glance image-list --visibility public |grep cirros | cut -f 2 -d  '|' | head -n 1 && deactivate"
     register: image_id
+    changed_when: False
     args:
       executable: /bin/bash
 
   - name: Check for test flavor
     shell: "source /home/rally/rally/bin/activate && rally deployment use {{ item.key }} &>/dev/null && source ~/.rally/openrc && nova flavor-list  |grep {{ tempest_test_flavor }} | cut -f 2 -d  '|' | head -n 1 && deactivate"
     register: flavor_id
+    changed_when: False
     args:
       executable: /bin/bash
 
   - name: Check for second test flavor
     shell: "source /home/rally/rally/bin/activate && rally deployment use {{ item.key }} &>/dev/null && source ~/.rally/openrc && nova flavor-list  |grep {{ tempest_second_test_flavor }} | cut -f 2 -d  '|' | head -n 1 && deactivate"
     register: second_flavor_id
+    changed_when: False
     args:
       executable: /bin/bash
 
@@ -61,14 +66,14 @@
     args:
       executable: /bin/bash
 
+  - name: Create skip list
+    template: src=tempest_skip_list.yml.j2 dest=/home/rally//{{ item.key }}-skip-list.yml owner=rally group=rally mode=0600
+
+  - name: Create run bash script
+    template: src=tempest_run.sh.j2 dest=/home/rally//{{ item.key }}-tempest_run.sh owner=rally group=rally mode=0700
+
   become_user: rally
   environment:
     ftp_proxy: ""
     http_proxy: ""
     https_proxy: ""
-
-- name: Create skip list
-  template: src=tempest_skip_list.yml.j2 dest=/home/rally//{{ item.key }}-skip-list.yml owner=rally group=rally mode=0600
-
-- name: Create run bash script
-  template: src=tempest_run.sh.j2 dest=/home/rally//{{ item.key }}-tempest_run.sh owner=rally group=rally mode=0700

--- a/tasks/tempest_verifiers.yml
+++ b/tasks/tempest_verifiers.yml
@@ -34,13 +34,13 @@
     args:
       executable: /bin/bash
 
-  - name: Check for flavor
+  - name: Check for test flavor
     shell: "source /home/rally/rally/bin/activate && rally deployment use {{ item.key }} &>/dev/null && source ~/.rally/openrc && nova flavor-list  |grep {{ tempest_test_flavor }} | cut -f 2 -d  '|' | head -n 1 && deactivate"
     register: flavor_id
     args:
       executable: /bin/bash
 
-  - name: Check for flavor
+  - name: Check for second test flavor
     shell: "source /home/rally/rally/bin/activate && rally deployment use {{ item.key }} &>/dev/null && source ~/.rally/openrc && nova flavor-list  |grep {{ tempest_second_test_flavor }} | cut -f 2 -d  '|' | head -n 1 && deactivate"
     register: second_flavor_id
     args:

--- a/templates/tempest.j2
+++ b/templates/tempest.j2
@@ -31,9 +31,9 @@ floating_ips = {{ rally_tempest_floating_ips }}
 [identity]
 ca_certificates_file = {{ tempest_ca_path }}
 
-{% if rally_tempest_extra_settings is defined %}
+{% if item.value.tempest_extra_settings is defined %}
 # Extra tempest.conf settings
-{% for param in rally_tempest_extra_settings %}
+{% for param in item.value.tempest_extra_settings %}
 {{ param }}
 {% endfor %}
 {% endif %}

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -119,7 +119,8 @@ function test_playbook(){
 }
 function extra_tests(){
 
-    ${APACHE_CTL} configtest || (echo "php --version was failed" && exit 100 )
+    echo "TEST: tree /home/rally"
+    tree /home/rally
 }
 
 
@@ -134,7 +135,7 @@ function main(){
     test_playbook_syntax
     test_playbook
 #    test_playbook_check
-#    extra_tests
+    extra_tests
 
 }
 

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -119,8 +119,8 @@ function test_playbook(){
 }
 function extra_tests(){
 
-    echo "TEST: tree /home/rally"
-    tree /home/rally
+    echo "TEST: ls -la /home/rally"
+    ls -la /home/rally
 }
 
 

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -28,6 +28,8 @@
           user_domain_name: Default
           user_project_domain_name: Default
           network_name: netowork_name_for_tempest
+          tempest_extra_settings: "{{ rally_tempest_extra_settings }}"
+          tempest_skip_tests: {}
         prodcloud:
           region: region1
           endpoint: prodcloud.fi:5000/v2.0/
@@ -42,6 +44,8 @@
           user_domain_name: Default
           user_project_domain_name: Default
           network_name: netowork_name_for_tempest
+          tempest_extra_settings: []
+          tempest_skip_tests: {}
 
    roles:
      - ansible-role-rally


### PR DESCRIPTION
Also
 - rename some tasks so they have unique names
 - set some tasks to changed_when: False because they only list/check things and stuff shouldn't change.