### PR TITLE
Print which verifier we are configuring

### DIFF
--- a/tasks/tempest_verifiers.yml
+++ b/tasks/tempest_verifiers.yml
@@ -1,4 +1,9 @@
 ---
+
+- name: "We are now configuring {{ item.key }}"
+  debug:
+    msg: "We are now configuring {{ item.key }}"
+
 - name: Check existing rally verifiers
   become_user: rally
   shell: "source /home/rally/rally/bin/activate && rally deployment use {{ item.key }} &>/dev/null && rally verify list-verifiers | grep -v WARNING && deactivate"


### PR DESCRIPTION
Nice to know which verifier is being configured when looking at ansible.
Without this it looks like 14 tasks are done, then 14 again with the
same name etc for each verifier/cloud.