### PR TITLE
Force concurrency to 1

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -94,8 +94,12 @@ tempest_ca_path: "/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt"
 # Set to True for the bash script to exit if we are not in a screen
 tempest_must_be_run_in_screen: False
 
+# How many threads to run. If not set, defaults to amount of CPUs.
+concurrency: 1
+
 # A way to add more settings:
 #rally_tempest_extra_settings:
 # - "mysetting = False"
 # - "[section1]"
 # - "setting2 = True"
+

--- a/templates/tempest_run.sh.j2
+++ b/templates/tempest_run.sh.j2
@@ -10,7 +10,7 @@ if [[ "$TERM" =~ "screen" ]]; then
   source /home/rally/rally/bin/activate
   rally deployment use {{ item.key }}
   rally verify use-verifier --id {{ item.key }}
-  rally verify start --skip-list {{ item.key }}-skip-list.yml --detailed $*
+  rally verify start --skip-list {{ item.key }}-skip-list.yml --concurrency {{ concurrency }} --detailed $*
 {% if item.value.tempest_manual_forloop_cleanup %}
   # Remove any resources with tempest in their names. Perhaps acceptable in a devel/test environment.
   source /home/rally/.rally/openrc


### PR DESCRIPTION
Run everything on single thread to get a minimal baseline ensuring
overlapping tests are not impacting each other.