### PR TITLE
Set volumes to error state when cleaning up

### DIFF
--- a/templates/tempest_run.sh.j2
+++ b/templates/tempest_run.sh.j2
@@ -15,7 +15,7 @@ if [[ "$TERM" =~ "screen" ]]; then
   # Remove any resources with tempest in their names. Perhaps acceptable in a devel/test environment.
   source /home/rally/.rally/openrc
   for snapshot in $(openstack volume snapshot list --all-projects -f csv -c ID -c Name |grep -i tempest-|tr -d '"'|cut -d "," -f1); do echo \#Deleting Tempest volume snapshot $snapshot; openstack volume snapshot delete $snapshot; done
-  for volume in $(openstack volume list --all-projects -f csv -c ID -c Name |grep -i tempest-|tr -d '"'|cut -d "," -f1); do echo \#Deleting Tempest volume $volume; openstack volume delete $volume; done
+  for volume in $(openstack volume list --all-projects -f csv -c ID -c Name |grep -i tempest-|tr -d '"'|cut -d "," -f1); do echo \#Deleting Tempest volume $volume; openstack volume set --state error $volume; openstack volume delete $volume; done
   for image in $(openstack image list -f csv -c ID -c Name |grep -i tempest-|tr -d '"'|cut -d "," -f1); do echo \#Deleting Tempest image $image; openstack image delete $image; done
   for project in $(openstack project list -f csv -c ID -c Name |grep -i tempest-|tr -d '"'|cut -d "," -f1); do echo \#Deleting Tempest project $project; openstack project delete $project;done
   for domain in $(openstack domain list -f csv -c ID -c Name|tr -d '"'|grep tempest-test_domain|cut -d "," -f1); do echo \#Disabling and deleting Tempest domain $domain; openstack domain set --disable $domain; openstack domain delete $domain; done


### PR DESCRIPTION
Before deleting a leftover volume, set it to error state to account
for volumes which are stuck in e.g. error_deleting state due to a
previous deletion attempt.