### PR TITLE
Clone in rally-openstack

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -103,3 +103,7 @@ concurrency: 1
 # - "[section1]"
 # - "setting2 = True"
 
+# Git clone rally-openstack because the sample scenarios are there and they are nice to have
+rally_openstack_gitrepo_source: https://github.com/openstack/rally-openstack
+rally_openstack_gitrepo_dest: /opt/rally/rally-openstack
+#rally_openstack_gitrepo_version: "master"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,3 +44,9 @@
 
 - import_tasks: tempest.yml
   when: configure_tempest
+
+- name: Create directories for deployments
+  file: path={{rally_openstack_gitrepo_dest|dirname}} owner=rally group=rally mode=0750 state=directory
+
+- name: clone openstack/rally-openstack to get the samples directory - useful for tasks
+  git: repo="{{ rally_openstack_gitrepo_source }}" dest="{{ rally_openstack_gitrepo_dest }}" version="{{ rally_openstack_gitrepo_version|default(omit) }}"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -13,7 +13,7 @@
        - "mysetting = False"
        - "[section1]"
        - "setting2 = True"
-     - rally_install_version: 'stable/0.12'
+     - rally_install_version: '1.6.0'
      - tempest_manual_forloop_cleanup: True
      - clouds:
         testcloud:


### PR DESCRIPTION
Because it has a nice
https://github.com/openstack/rally-openstack/tree/master/samples

directory which doesn't come in with "pip install rally-openstack"

Before they used to be in openstack/rally but in

https://github.com/openstack/rally/commit/7addc521c1523f343b7bc15773a9a5d3a413cbf8

they were moved to rally-openstack