### PR TITLE
Speed up rally cinder test

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -76,6 +76,9 @@ tempest_second_test_flavor: m1.small
 
 tempest_ipv6_support: False
 
+# Volume size for tempest test
+tempest_volume_size: 1
+
 # For some reason this is empty if not explicity set
 tempest_ca_path: "/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt"
 

--- a/templates/tempest.j2
+++ b/templates/tempest.j2
@@ -19,7 +19,7 @@ discoverability = {{ rally_tempest_swift_discoverability }}
 {% endif %}
 
 [volume]
-volume_size = 1
+volume_size = {{ tempest_volume_size }}
 
 [network-feature-enabled]
 ipv6_subnet_attributes = False

--- a/templates/tempest.j2
+++ b/templates/tempest.j2
@@ -19,7 +19,7 @@ discoverability = {{ rally_tempest_swift_discoverability }}
 {% endif %}
 
 [volume]
-volume_size = 10
+volume_size = 1
 
 [network-feature-enabled]
 ipv6_subnet_attributes = False


### PR DESCRIPTION
This test fails sometimes in our devel environment because it takes to long,
the timeout seems to be 300 seconds. It takes ~150 seconds in our test env.
tempest.api.volume.test_volumes_actions.VolumesActionsTest.test_volume_upload
By decreaing the size it should now succeed everytime.

CCCP-2836