### PR TITLE
Quote values in string fields

### DIFF
--- a/tasks/tempest_verifiers.yml
+++ b/tasks/tempest_verifiers.yml
@@ -92,7 +92,7 @@
       name: "Run tempest against {{ item.key }}"
       user: rally
       hour: "{{ item.value.tempest_cron_run_hour }}"
-      minute: 0
+      minute: "0"
       job: /home/rally/{{ item.key }}-tempest_run.sh --tag cron_$(date +\%Y_\%m_\%d_\%H)
     when: item.value.configure_tempest_cron | default('false')
 


### PR DESCRIPTION
Removes this warning (seen with ansible 2.9.1):

<pre>

TASK [ansible-role-rally-scenarios : Configure cronjob for deployment
epouta-test]
*************************************************************************
[WARNING]: The value 0 (type int) in a string field was converted to
u'0' (type string). If this does not look like what you expect, quote
the entire value
to ensure it does not change.
</pre>