### PR TITLE
 Convert cirros image to raw format 

### DIFF
--- a/tasks/tempest.yml
+++ b/tasks/tempest.yml
@@ -1,11 +1,21 @@
 ---
-- name: Get image
-  get_url:
-    url: "http://download.cirros-cloud.net/0.3.5/cirros-0.3.5-x86_64-disk.img"
-    dest: "/tmp/cirros-0.3.5-x86_64-disk.img"
+- name: Get image locally
+  local_action:
+    get_url:
+      url: "http://download.cirros-cloud.net/0.3.5/cirros-0.3.5-x86_64-disk.img"
+      dest: "/tmp/cirros-0.3.5-x86_64-disk.img"
 
 - name: Convert image to raw format
-  command: "qemu-img convert -f qcow2 -O raw /tmp/cirros-0.3.5-x86_64-disk.img /tmp/cirros-0.3.5-x86_64-disk.img.raw"
+  local_action:
+    command: "qemu-img convert -f qcow2 -O raw /tmp/cirros-0.3.5-x86_64-disk.img /tmp/cirros-0.3.5-x86_64-disk.img.raw"
+
+- name: Upload image to rally server
+  copy:
+    src: /tmp/cirros-0.3.5-x86_64-disk.img.raw
+    dest: /tmp/cirros-0.3.5-x86_64-disk.img.raw
+    owner: root
+    group: root
+    mode: '0644'
 
 - include_tasks: tempest_verifiers.yml
   with_dict: "{{ clouds }}"

--- a/tasks/tempest.yml
+++ b/tasks/tempest.yml
@@ -1,13 +1,17 @@
 ---
 - name: Get image locally
+  become: false
   local_action:
-    get_url:
-      url: "http://download.cirros-cloud.net/0.3.5/cirros-0.3.5-x86_64-disk.img"
-      dest: "/tmp/cirros-0.3.5-x86_64-disk.img"
+    module: get_url
+    url: "http://download.cirros-cloud.net/0.3.5/cirros-0.3.5-x86_64-disk.img"
+    dest: "/tmp/cirros-0.3.5-x86_64-disk.img"
+    use_proxy: no
 
 - name: Convert image to raw format
+  become: false
   local_action:
-    command: "qemu-img convert -f qcow2 -O raw /tmp/cirros-0.3.5-x86_64-disk.img /tmp/cirros-0.3.5-x86_64-disk.img.raw"
+    module: command
+    cmd: "qemu-img convert -f qcow2 -O raw /tmp/cirros-0.3.5-x86_64-disk.img /tmp/cirros-0.3.5-x86_64-disk.img.raw"
 
 - name: Upload image to rally server
   copy:

--- a/tasks/tempest.yml
+++ b/tasks/tempest.yml
@@ -4,5 +4,8 @@
     url: "http://download.cirros-cloud.net/0.3.5/cirros-0.3.5-x86_64-disk.img"
     dest: "/tmp/cirros-0.3.5-x86_64-disk.img"
 
+- name: Convert image to raw format
+  command: "qemu-img convert -f qcow2 -O raw /tmp/cirros-0.3.5-x86_64-disk.img /tmp/cirros-0.3.5-x86_64-disk.img.raw"
+
 - include_tasks: tempest_verifiers.yml
   with_dict: "{{ clouds }}"

--- a/tasks/tempest_verifiers.yml
+++ b/tasks/tempest_verifiers.yml
@@ -30,7 +30,7 @@
 
     # Can't use os_image since we need to source the rally deployment
   - name: Upload cirros image to openstack
-    shell: "source /home/rally/rally/bin/activate && rally deployment use {{ item.key }} &>/dev/null && source ~/.rally/openrc && glance image-create --name cirros --visibility public --file /tmp/cirros-0.3.5-x86_64-disk.img --container-format bare --disk-format qcow2 && deactivate"
+    shell: "source /home/rally/rally/bin/activate && rally deployment use {{ item.key }} &>/dev/null && source ~/.rally/openrc && glance image-create --name cirros --visibility public --file /tmp/cirros-0.3.5-x86_64-disk.img.raw --container-format bare --disk-format raw && deactivate"
     when: existing_images.rc == 1
     args:
       executable: /bin/bash


### PR DESCRIPTION
We have started using raw images instead of qcow2. We should thus
perform our automatic testing using raw images. This commit converts the
qcow2 image to raw and ensures that openstack is aware of the new image
format.