### PR TITLE
Trigger reconfiguration if verifier is created

### DIFF
--- a/tasks/tempest_verifiers.yml
+++ b/tasks/tempest_verifiers.yml
@@ -16,6 +16,7 @@
   become_user: rally
   shell: "source /home/rally/rally/bin/activate && rally deployment use {{ item.key }} &>/dev/null && rally verify create-verifier --type tempest --name {{ item.key }} --source {{ tempest_source }} --version {{ tempest_version }}  && deactivate"
   when: item.key not in verifiers.stdout | default([])
+  register: verifier_created
   args:
     executable: /bin/bash
 
@@ -83,11 +84,11 @@
     template: src=tempest.j2 dest=/home/rally/tempest_configs/{{ item.key }}.tempest owner=rally group=rally mode=0700
     register: reg_tempest_config
 
-  - name: Configure rally verifier if templating in the templest config file task changed
+  - name: Configure rally verifier if templating in the templest config file task changed or new verifier created
     shell: "source /home/rally/rally/bin/activate && rally deployment use {{ item.key }} &>/dev/null && rally verify use-verifier --id {{ item.key }} &&  rally verify configure-verifier --extend /home/rally/tempest_configs/{{ item.key }}.tempest && deactivate"
     args:
       executable: /bin/bash
-    when: reg_tempest_config.changed
+    when: reg_tempest_config.changed or verifier_created.stat.exists
 
   - name: Template in skip list
     template: src=tempest_skip_list.yml.j2 dest=/home/rally//{{ item.key }}-skip-list.yml owner=rally group=rally mode=0600

--- a/tasks/tempest_verifiers.yml
+++ b/tasks/tempest_verifiers.yml
@@ -88,7 +88,7 @@
     shell: "source /home/rally/rally/bin/activate && rally deployment use {{ item.key }} &>/dev/null && rally verify use-verifier --id {{ item.key }} &&  rally verify configure-verifier --extend /home/rally/tempest_configs/{{ item.key }}.tempest && deactivate"
     args:
       executable: /bin/bash
-    when: reg_tempest_config.changed or verifier_created.stat.exists
+    when: reg_tempest_config.changed or verifier_created is not skipped
 
   - name: Template in skip list
     template: src=tempest_skip_list.yml.j2 dest=/home/rally//{{ item.key }}-skip-list.yml owner=rally group=rally mode=0600


### PR DESCRIPTION
Currently reconfiguration of the verifier is triggered only if a local
copy of the configuration is changed. In case the current verifier is
deleted and re-created, then the local copy of the configuration is not
changed, meaning that the code will not reconfigure the just-created
verifier.

The proposed change adds a trigger to the reconfiguration: if the
verifier has just been created, then perform the reconfiguration